### PR TITLE
Fix duplicate init in TokenParser

### DIFF
--- a/sparktts/utils/token_parser.py
+++ b/sparktts/utils/token_parser.py
@@ -64,14 +64,10 @@ EMO_MAP = {
 
 
 class TokenParser:
-    """Turn label to special token"""
+    """Turn label to special token."""
 
-    def __init__(self):
-        pass
-
-    """Parse the attributes of a person."""
-
-    def __init__(self):
+    def __init__(self) -> None:
+        """Initialize the parser for speaker attributes."""
         pass
 
     @staticmethod


### PR DESCRIPTION
## Summary
- fix duplicate `__init__` in `TokenParser`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683fba04f7dc832bbdfaaf5442d628b7