### PR TITLE
Add Flask API server with tests

### DIFF
--- a/flask_api.py
+++ b/flask_api.py
@@ -1,0 +1,102 @@
+import argparse
+import base64
+import io
+import platform
+
+import os
+import soundfile as sf
+import tempfile
+import torch
+from flask import Flask, jsonify, request
+
+from cli.SparkTTS import SparkTTS
+
+
+def create_app(model_dir="pretrained_models/Spark-TTS-0.5B", device=0):
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+
+    # Determine device
+    if platform.system() == "Darwin" and torch.backends.mps.is_available():
+        device = torch.device(f"mps:{device}")
+    elif torch.cuda.is_available():
+        device = torch.device(f"cuda:{device}")
+    else:
+        device = torch.device("cpu")
+
+    model = SparkTTS(model_dir, device)
+
+    @app.route("/health", methods=["GET"])
+    def health():
+        return jsonify({"status": "ok"})
+
+    @app.route("/tts", methods=["POST"])
+    def tts():
+        data = request.get_json(silent=True) or {}
+        text = data.get("text") or request.form.get("text")
+        if not text:
+            return jsonify({"error": "Missing text"}), 400
+
+        prompt_text = data.get("prompt_text") or request.form.get("prompt_text")
+
+        # Handle uploaded audio as base64 string or multipart file
+        prompt_speech_b64 = data.get("prompt_speech") or request.form.get("prompt_speech")
+        prompt_file = request.files.get("prompt_speech")
+        tmp_path = None
+        if prompt_file:
+            speech_bytes = prompt_file.read()
+        elif prompt_speech_b64:
+            try:
+                speech_bytes = base64.b64decode(prompt_speech_b64)
+            except Exception:
+                return jsonify({"error": "Invalid prompt_speech"}), 400
+        else:
+            speech_bytes = None
+
+        if speech_bytes is not None:
+            tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+            tmp_file.write(speech_bytes)
+            tmp_file.flush()
+            tmp_path = tmp_file.name
+            tmp_file.close()
+
+        gender = data.get("gender") or request.form.get("gender")
+        pitch = data.get("pitch") or request.form.get("pitch")
+        speed = data.get("speed") or request.form.get("speed")
+
+        with torch.no_grad():
+            wav = model.inference(
+                text,
+                tmp_path,
+                prompt_text=prompt_text,
+                gender=gender,
+                pitch=pitch,
+                speed=speed,
+            )
+
+        if tmp_path:
+            os.unlink(tmp_path)
+        if isinstance(wav, torch.Tensor):
+            wav = wav.cpu().numpy()
+        buffer = io.BytesIO()
+        sf.write(buffer, wav, samplerate=16000, format="WAV")
+        buffer.seek(0)
+        audio_b64 = base64.b64encode(buffer.read()).decode("utf-8")
+        return jsonify({"audio": audio_b64})
+
+    return app
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="SparkTTS Flask API server")
+    parser.add_argument("--model_dir", default="pretrained_models/Spark-TTS-0.5B")
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=5000)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    app = create_app(args.model_dir, args.device)
+    app.run(host=args.host, port=args.port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ torchaudio==2.5.1
 tqdm==4.66.5
 transformers==4.46.2
 gradio==5.23.1 
+
+Flask==3.0.3
+pytest==8.2.2

--- a/tests/test_flask_api.py
+++ b/tests/test_flask_api.py
@@ -1,0 +1,38 @@
+import base64
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from flask_api import create_app
+
+
+@patch('flask_api.SparkTTS')
+def test_health_endpoint(mock_sparktts):
+    mock_sparktts.return_value = MagicMock()
+    app = create_app()
+    client = app.test_client()
+    resp = client.get('/health')
+    assert resp.status_code == 200
+    assert resp.get_json() == {'status': 'ok'}
+
+
+@patch('flask_api.SparkTTS')
+def test_tts_endpoint(mock_sparktts):
+    mock_model = MagicMock()
+    mock_model.inference.return_value = np.zeros(16000)
+    mock_sparktts.return_value = mock_model
+
+    app = create_app()
+    client = app.test_client()
+    audio_b64 = base64.b64encode(b'00').decode('utf-8')
+    resp = client.post('/tts', json={'text': 'hello', 'prompt_speech': audio_b64})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'audio' in data
+    audio_bytes = base64.b64decode(data['audio'])
+    assert len(audio_bytes) > 0
+    with open('tests/generated_audio.wav', 'wb') as f:
+        f.write(audio_bytes)
+    args, kwargs = mock_model.inference.call_args
+    assert args[0] == 'hello'
+    assert args[1] is not None


### PR DESCRIPTION
## Summary
- add `flask_api.py` implementing a Flask TTS API
- include unit tests for the new server
- install Flask and pytest in requirements
- update TTS endpoint to accept uploaded audio data instead of local file paths

## Testing
- `pip install -q -r requirements.txt` *(fails: Operation cancelled)*
- `pytest -q` *(fails: missing 'torch' and 'soundfile')*


------
https://chatgpt.com/codex/tasks/task_e_684007e6f3f0832bbca722a9dc6dcb53